### PR TITLE
bump slonik to 28.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
+dist: focal
 node_js:
   - node
-  - 14
+  - lts/*
+before_install:
+  - npm install -g typescript
 script:
   - npm run build
   - npm run test

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/sinon": "^10.0.6",
-    "ava": "^3.15.0",
+    "ava": "^4.3.1",
     "coveralls": "^3.1.1",
     "eslint": "^8.5.0",
     "eslint-config-canonical": "^32.48.8",
-    "gitdown": "^3.1.4",
+    "gitdown": "^3.1.5",
     "husky": "^4.2.3",
     "nyc": "^15.1.0",
-    "semantic-release": "^18.0.1",
+    "semantic-release": "^19.0.3",
     "sinon": "^12.0.1",
     "slonik": "^26.2.2",
     "ts-node": "^10.4.0"

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "nyc": "^15.1.0",
     "semantic-release": "^19.0.3",
     "sinon": "^12.0.1",
-    "slonik": "^26.2.2",
+    "slonik": "^28.1.1",
     "ts-node": "^10.4.0"
   },
   "peerDependencies": {
-    "slonik": "*"
+    "slonik": "^28.*"
   },
   "engines": {
     "node": ">=8.0"

--- a/src/routines/update.ts
+++ b/src/routines/update.ts
@@ -7,7 +7,7 @@ import {
   sql,
 } from 'slonik';
 import type {
-  DatabaseConnectionType,
+  DatabaseConnection,
 } from 'slonik';
 import type {
   NamedAssignmentPayload,
@@ -22,7 +22,7 @@ type UpdateResultType = {
 };
 
 export const update = async (
-  connection: DatabaseConnectionType,
+  connection: DatabaseConnection,
   tableName: string,
   namedAssignmentPayload: NamedAssignmentPayload,
   booleanExpressionValues: Record<string, boolean | number | string | null> = {},

--- a/src/routines/updateDistinct.ts
+++ b/src/routines/updateDistinct.ts
@@ -2,7 +2,7 @@ import {
   sql,
 } from 'slonik';
 import type {
-  DatabaseConnectionType,
+  DatabaseConnection,
 } from 'slonik';
 import type {
   NamedAssignmentPayload,
@@ -17,7 +17,7 @@ type UpdateDistinctResultType = {
 };
 
 export const updateDistinct = async (
-  connection: DatabaseConnectionType,
+  connection: DatabaseConnection,
   tableName: string,
   namedAssignmentPayload: NamedAssignmentPayload,
   booleanExpressionValues: Record<string, boolean | number | string | null> = {},

--- a/src/routines/upsert.ts
+++ b/src/routines/upsert.ts
@@ -8,15 +8,15 @@ import {
   sql,
 } from 'slonik';
 import type {
-  DatabaseConnectionType,
-  ValueExpressionType,
+  DatabaseConnection,
+  ValueExpression,
 } from 'slonik';
 import {
   Logger,
 } from '../Logger';
 
 type NamedValueBindingsType = {
-  readonly [key: string]: ValueExpressionType,
+  readonly [key: string]: ValueExpression,
 };
 
 type UpsertConfigurationType = {
@@ -36,7 +36,7 @@ const defaultConfiguration = {
 };
 
 export const upsert = async (
-  connection: DatabaseConnectionType,
+  connection: DatabaseConnection,
   tableName: string,
   namedValueBindings: NamedValueBindingsType,
   inputUniqueConstraintColumnNames: readonly string[] | null = null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type {
-  ValueExpressionType,
+  ValueExpression,
 } from 'slonik';
 
 export type NamedAssignmentPayload = {
-  [key: string]: ValueExpressionType,
+  [key: string]: ValueExpression,
 };

--- a/src/utilities/assignmentList.ts
+++ b/src/utilities/assignmentList.ts
@@ -2,7 +2,7 @@ import {
   sql,
 } from 'slonik';
 import type {
-  ListSqlTokenType,
+  ListSqlToken,
 } from 'slonik';
 import type {
   NamedAssignmentPayload,
@@ -13,7 +13,7 @@ import {
 
 export const assignmentList = (
   namedAssignment: NamedAssignmentPayload,
-): ListSqlTokenType => {
+): ListSqlToken => {
   const values = Object.values(
     Object.entries(namedAssignment).map(([
       column,


### PR DESCRIPTION
* fix some vulnerabilities
* update types to be compatible with slonik `28.x`
* force `peerDependencies` to `28.x` since the types renaming is a breaking change